### PR TITLE
Fix: Background Image can not be set as Background color has in Non-nullifiable default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The `setup` function accepts the following table:
 	font = "VictorMono NF=34;Noto Emoji",
 	-- the theme to use, depends on themes available to silicon
 	theme = "gruvbox-dark",
-	-- the background color outside the rendered os window
-	background = "#076678",
+	-- the background color outside the rendered os window (in hexcode string e.g "#076678")
+	background = nil,
 	-- a path to a background image
 	background_image = nil,
 	-- the paddings to either side

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -3,7 +3,7 @@ local M = {}
 M.default_opts = {
 	font = "VictorMono NF=34;Noto Emoji",
 	theme = "gruvbox-dark",
-	background = "#076678",
+	background = nil,
 	background_image = nil,
 	pad_horiz = 100,
 	pad_vert = 80,


### PR DESCRIPTION
# Context

As the 2 arguments can not be supplied together (as per `silicon` warning), a default `background` argument cause `background_image` impossible to be injected.

# Solution

Remove default `background` argument, let the `silicon` binary decide.