### PR TITLE
fix: correct path displayed in notification for generated files

### DIFF
--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -210,9 +210,17 @@ M.start = function(args, options)
 			)
 		else
 			local genInfo = function()
-				if string.sub(tostring(M.filename), 1, 1) == "~" or string.sub(tostring(M.filename), 1, 1) == "." then
+				if string.sub(tostring(M.filename), 1, 1) == "~" then
 					return "silicon generated image at: " .. M.filename
 				end
+
+				if string.sub(tostring(M.filename), 1, 2) == "./" then
+					return "silicon generated image at: "
+						.. vim.fn.getcwd()
+						.. "/"
+						.. string.sub(tostring(M.filename), 3)
+				end
+
 				return "silicon generated image at: " .. vim.fn.getcwd() .. "/" .. M.filename
 			end
 

--- a/lua/silicon/init.lua
+++ b/lua/silicon/init.lua
@@ -209,14 +209,14 @@ M.start = function(args, options)
 				{ title = "nvim-silicon" }
 			)
 		else
-			local filename = M.filename
-				and '"' .. vim.fn.getcwd() .. "/" .. M.filename .. '"'
-				or 'a the location specified in your config file'
-			return vim.notify(
-				"silicon generated an image at " .. filename,
-				vim.log.levels.INFO,
-				{ title = "nvim-silicon" }
-			)
+			local genInfo = function()
+				if string.sub(tostring(M.filename), 1, 1) == "~" or string.sub(tostring(M.filename), 1, 1) == "." then
+					return "silicon generated image at: " .. M.filename
+				end
+				return "silicon generated image at: " .. vim.fn.getcwd() .. "/" .. M.filename
+			end
+
+			return vim.notify(genInfo(), vim.log.levels.INFO, { title = "nvim-silicon" })
 		end
 	end
 end


### PR DESCRIPTION
At the moment, when you specify a filepath using the `output` key, the generated message shows the current working directory before the actual filepath where the image is store.

Example:

```vim
silicon generated an image at "/home/cheezaram/dotfiles.pub/~/Pictures/2024-03-02T18-18-18_code.png"
```

or

```vim
silicon generated an image at "/home/cheezaram/dotfiles.pub/./Pictures/2024-03-02T18-18-18_code.png"
```

This PR changes that behaviour so you have

```vim
silicon generated an image at: ~/Pictures/2024-03-02T18-18-18_code.png
```

or

```vim
silicon generated an image at: ./Pictures/2024-03-02T18-18-18_code.png
```