### PR TITLE
Fix: added missing guard clause around returncode debug print statement.

### DIFF
--- a/lua/nvim-silicon/init.lua
+++ b/lua/nvim-silicon/init.lua
@@ -193,7 +193,9 @@ M.cmd = function(args, options)
 			code = vim.fn.system(cmdline, lines)
 			code = string.gsub(code, "\n", "")
 			ret.code = code
-			print("returncode: " .. M.utils.dump(code))
+			if options.debug then
+				print("returncode: " .. M.utils.dump(code))
+			end
 			if code ~= "" then
 				vim.notify(
 					"silicon call with filetype error: " .. code .. ", trying extension...",


### PR DESCRIPTION
# Issue
The returncode message is printed even if `debug = false` is set accordingly, after looking into the source code, I saw that that section was without its guard clause - differently from other print sections.

When using a plugin like [nvim-notify](https://github.com/rcarriga/nvim-notify) or others that hijack the print handler, that print statement will be transformed into a notification and will be rendered alongside the intended notification - which may impact other plugins as well.
![Notification](https://github.com/user-attachments/assets/3548fbcd-ed12-4d38-b5c3-45c34cd9648f)

# Solution
This PR just adds that clause, which also fixes the notification issue.